### PR TITLE
FreeBSD Support & CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: x86_64-unknown-freebsd
-          - os: ubuntu-latest
-            target: i686-unknown-freebsd
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -64,6 +60,27 @@ jobs:
       run: |
         cargo build --target ${{ matrix.target }}
         cargo build --target ${{ matrix.target }} --all-features
+
+  freebsd:
+    runs-on: ubuntu-latest
+    name: Test on FreeBSD
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Test
+      id: test
+      uses: vmactions/freebsd-vm@v1.2.1
+      with:
+        sync: rsync
+        copyback: false
+        prepare: |
+          pkg install -y rustup-init
+          rustup-init -y --profile minimal
+        run: |
+          rustup target add i686-unknown-freebsd
+          rustup --version
+          rustc --version
+          cargo test --all-features
 
   ci:
     name: CI
@@ -98,7 +115,7 @@ jobs:
 
   cd:
     name: CD
-    needs: [msrv, build, ci]
+    needs: [msrv, build, ci, freebsd]
     runs-on: ubuntu-latest
 
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-ioctl"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21b9069801ea0ceb4181430bd1de6a5dc0f564bb12fecfa9be970e89c5e0d0a"
+checksum = "543f92dc2a5109c480df389ffbc132a8a72f5be63b52adf0c0a5d41f5a0852d6"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.85"
 
 [dependencies]
 libc = "0.2.172"
-linux-ioctl = "0.2.2"
+linux-ioctl = "0.2.3"
 log = "0.4.27"
 serde = { version = "1.0.219", optional = true }
 

--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -13,7 +13,7 @@ use std::{
         },
     },
     path::{Path, PathBuf},
-    ptr, slice,
+    slice,
     time::Instant,
 };
 
@@ -489,7 +489,7 @@ impl Evdev {
     /// (including this one) fail with `ENODEV`.
     pub fn revoke(&self) -> io::Result<()> {
         unsafe {
-            self.ioctl("EVIOCREVOKE", EVIOCREVOKE, ptr::null())?;
+            self.ioctl("EVIOCREVOKE", EVIOCREVOKE, 0)?;
             Ok(())
         }
     }

--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -208,7 +208,12 @@ impl Evdev {
     }
 
     /// Executes `ioctl` and adds context to the error.
-    unsafe fn ioctl<T>(&self, name: &'static str, ioctl: Ioctl<T>, arg: T) -> io::Result<c_int> {
+    pub(crate) unsafe fn ioctl<T>(
+        &self,
+        name: &'static str,
+        ioctl: Ioctl<T>,
+        arg: T,
+    ) -> io::Result<c_int> {
         match unsafe { ioctl.ioctl(self, arg) } {
             Ok(ok) => Ok(ok),
             Err(e) => {

--- a/src/raw/uinput.rs
+++ b/src/raw/uinput.rs
@@ -50,17 +50,46 @@ pub struct uinput_abs_setup {
 
 pub const UI_ABS_SETUP: Ioctl<*const uinput_abs_setup> = _IOW(UINPUT_IOCTL_BASE, 4);
 
-pub const UI_SET_EVBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 100).with_direct_arg();
-pub const UI_SET_KEYBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 101).with_direct_arg();
-pub const UI_SET_RELBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 102).with_direct_arg();
-pub const UI_SET_ABSBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 103).with_direct_arg();
-pub const UI_SET_MSCBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 104).with_direct_arg();
-pub const UI_SET_LEDBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 105).with_direct_arg();
-pub const UI_SET_SNDBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 106).with_direct_arg();
-pub const UI_SET_FFBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 107).with_direct_arg();
-pub const UI_SET_PHYS: Ioctl<*const c_char> = _IOW(UINPUT_IOCTL_BASE, 108).with_direct_arg();
-pub const UI_SET_SWBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 109).with_direct_arg();
-pub const UI_SET_PROPBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 110).with_direct_arg();
+#[cfg(target_os = "freebsd")]
+mod ioctls {
+    use linux_ioctl::IOC_VOID;
+
+    use super::*;
+
+    const fn _IOWINT(group: u8, nr: u8) -> Ioctl<c_int> {
+        _IOC(IOC_VOID, group, nr, size_of::<c_int>())
+    }
+
+    pub const UI_SET_EVBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 100);
+    pub const UI_SET_KEYBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 101);
+    pub const UI_SET_RELBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 102);
+    pub const UI_SET_ABSBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 103);
+    pub const UI_SET_MSCBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 104);
+    pub const UI_SET_LEDBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 105);
+    pub const UI_SET_SNDBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 106);
+    pub const UI_SET_FFBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 107);
+    pub const UI_SET_PHYS: Ioctl<*const c_char> = _IO(UINPUT_IOCTL_BASE, 108).with_arg();
+    pub const UI_SET_SWBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 109);
+    pub const UI_SET_PROPBIT: Ioctl<c_int> = _IOWINT(UINPUT_IOCTL_BASE, 110);
+}
+
+#[cfg(not(target_os = "freebsd"))]
+mod ioctls {
+    use super::*;
+    pub const UI_SET_EVBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 100).with_direct_arg();
+    pub const UI_SET_KEYBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 101).with_direct_arg();
+    pub const UI_SET_RELBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 102).with_direct_arg();
+    pub const UI_SET_ABSBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 103).with_direct_arg();
+    pub const UI_SET_MSCBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 104).with_direct_arg();
+    pub const UI_SET_LEDBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 105).with_direct_arg();
+    pub const UI_SET_SNDBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 106).with_direct_arg();
+    pub const UI_SET_FFBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 107).with_direct_arg();
+    pub const UI_SET_PHYS: Ioctl<*const c_char> = _IOW(UINPUT_IOCTL_BASE, 108).with_direct_arg();
+    pub const UI_SET_SWBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 109).with_direct_arg();
+    pub const UI_SET_PROPBIT: Ioctl<c_int> = _IOW(UINPUT_IOCTL_BASE, 110).with_direct_arg();
+}
+
+pub use ioctls::*;
 
 pub const UI_BEGIN_FF_UPLOAD: Ioctl<*mut uinput_ff_upload> = _IOWR(UINPUT_IOCTL_BASE, 200);
 pub const UI_END_FF_UPLOAD: Ioctl<*const uinput_ff_upload> = _IOW(UINPUT_IOCTL_BASE, 201);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -137,8 +137,11 @@ impl MtStorage {
             this.data[start_idx] = mt_code.into();
 
             unsafe {
-                EVIOCGMTSLOTS((this.slots as usize + 1) * 4)
-                    .ioctl(evdev, this.data[start_idx..].as_mut_ptr().cast())?;
+                evdev.ioctl(
+                    "EVIOCGMTSLOTS",
+                    EVIOCGMTSLOTS((this.slots as usize + 1) * 4),
+                    this.data[start_idx..].as_mut_ptr().cast(),
+                )?;
             }
         }
         this.data.shrink_to_fit();

--- a/tests/loopback/events.rs
+++ b/tests/loopback/events.rs
@@ -70,6 +70,10 @@ fn evdev2uinput(t: &mut Tester, events: &[InputEvent]) -> io::Result<()> {
     }
     for expected in events {
         let recv = t.uinput.events().next().unwrap()?;
+        if matches!(recv.kind(), EventKind::Syn(ev) if ev.syn() == Syn::REPORT) {
+            // FreeBSD inserts SYN_REPORT events into the uinput stream, Linux does not.
+            continue;
+        }
         if !events_eq(&recv, expected) {
             panic!("expected {expected:?} in uinput device, got {recv:?}");
         }

--- a/tests/loopback/events.rs
+++ b/tests/loopback/events.rs
@@ -70,10 +70,6 @@ fn evdev2uinput(t: &mut Tester, events: &[InputEvent]) -> io::Result<()> {
     }
     for expected in events {
         let recv = t.uinput.events().next().unwrap()?;
-        if matches!(recv.kind(), EventKind::Syn(ev) if ev.syn() == Syn::REPORT) {
-            // FreeBSD inserts SYN_REPORT events into the uinput stream, Linux does not.
-            continue;
-        }
         if !events_eq(&recv, expected) {
             panic!("expected {expected:?} in uinput device, got {recv:?}");
         }
@@ -170,6 +166,7 @@ fn test_single_key_event() -> io::Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "test broken on FreeBSD")]
 fn test_led() -> io::Result<()> {
     let mut tester = Tester::get();
 
@@ -424,6 +421,10 @@ fn test_overflow_resync() -> io::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "event masks are not supported on FreeBSD"
+)]
 fn test_event_mask_state() -> io::Result<()> {
     let mut tester = Tester::get();
 
@@ -446,6 +447,10 @@ fn test_event_mask_state() -> io::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "event masks are not supported on FreeBSD"
+)]
 fn test_event_mask() -> io::Result<()> {
     let mut tester = Tester::get();
 
@@ -474,6 +479,10 @@ fn test_event_mask() -> io::Result<()> {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "freebsd",
+    ignore = "event masks are not supported on FreeBSD"
+)]
 fn test_rel_mask() -> io::Result<()> {
     let mut tester = Tester::get();
 

--- a/tests/loopback/ff.rs
+++ b/tests/loopback/ff.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "freebsd"))] // FreeBSD does not support force-feedback (stubbed out)
+
 use std::{collections::HashSet, error::Error, io, sync::mpsc};
 
 use evdevil::{

--- a/tests/loopback/main.rs
+++ b/tests/loopback/main.rs
@@ -207,6 +207,7 @@ impl Tester {
     }
 
     /// Schedules `thread` to happen in a background thread.
+    #[cfg_attr(target_os = "freebsd", expect(dead_code))]
     fn with_evdev_thread(
         &mut self,
         thread: impl FnOnce(&mut Evdev) -> io::Result<()> + Send + 'static,

--- a/tests/loopback/repeat.rs
+++ b/tests/loopback/repeat.rs
@@ -8,6 +8,7 @@ use evdevil::{
 use crate::{KEY_REPEAT, Tester};
 
 #[test]
+#[cfg_attr(target_os = "freebsd", ignore = "events do not echo back on FreeBSD")]
 fn get_set_repeat() -> io::Result<()> {
     let t = Tester::get();
 


### PR DESCRIPTION
The FreeBSD implementation is kinda broken on 32-bit x86 processes. It expects uinput events to always conform to the x86_64 definition of `input_event`, but evdev events use the 32-bit x86 definition (of `timeval` and `time_t`).
We don't try to work around that, so some features will just not work there. C code has the same problem from what I can tell.