### PR TITLE
Support `async` hotplug events

### DIFF
--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -133,7 +133,15 @@ impl Evdev {
     fn open_unchecked(path: PathBuf) -> io::Result<Self> {
         let now = Instant::now();
 
-        let file = Self::try_open(&path)?;
+        let file = match Self::try_open(&path) {
+            Ok(file) => file,
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!("failed to open '{}': {e}", path.display()),
+                ));
+            }
+        };
         let this = Self { file, path };
         let version = this.driver_version()?;
         log::debug!(

--- a/src/hotplug/async.rs
+++ b/src/hotplug/async.rs
@@ -1,0 +1,60 @@
+use std::{io, os::fd::AsRawFd, task::Poll};
+
+use crate::{Evdev, hotplug::HotplugMonitor, util::r#async::AsyncHelper};
+
+/// An asynchronous iterator over hotplug events.
+///
+/// Returned by [`HotplugMonitor::async_iter`].
+#[derive(Debug)]
+pub struct AsyncIter<'a> {
+    helper: AsyncHelper,
+    mon: &'a HotplugMonitor,
+}
+
+impl<'a> AsyncIter<'a> {
+    pub(crate) fn new(mon: &'a HotplugMonitor) -> io::Result<Self> {
+        Ok(Self {
+            helper: AsyncHelper::new(mon.as_raw_fd())?,
+            mon,
+        })
+    }
+
+    /// Asynchronously waits for the next hotplug event.
+    pub async fn next_event(&self) -> io::Result<Evdev> {
+        self.helper
+            .asyncify(|| match self.mon.iter().next() {
+                Some(res) => Poll::Ready(res),
+                None => Poll::Pending,
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, pin::pin};
+
+    use crate::{
+        hotplug::HotplugMonitor, test::AssertPending, uinput::UinputDevice,
+        util::r#async::with_runtime,
+    };
+
+    #[test]
+    fn smoke() -> io::Result<()> {
+        with_runtime(|rt| {
+            const DEVNAME: &str = "-@-rust-async-hotplug-test-@-";
+
+            let mon = HotplugMonitor::new()?;
+
+            let events = mon.async_iter()?;
+            let mut fut = pin!(events.next_event());
+            rt.block_on(AssertPending(fut.as_mut()));
+
+            let _uinput = UinputDevice::builder()?.build(DEVNAME)?;
+
+            rt.block_on(fut)?;
+
+            Ok(())
+        })
+    }
+}

--- a/src/reader/async.rs
+++ b/src/reader/async.rs
@@ -3,9 +3,9 @@
 #[cfg(all(not(doc), feature = "tokio", feature = "async-io"))]
 compile_error!("`tokio` and `async-io` are mutually exclusive; only one may be enabled");
 
-use std::io;
+use std::{io, os::fd::AsRawFd, task::Poll};
 
-use crate::{EventReader, event::InputEvent, reader::Report};
+use crate::{EventReader, event::InputEvent, reader::Report, util::r#async::AsyncHelper};
 
 /// An asynchronous iterator over [`Report`]s emitted by the device.
 ///
@@ -16,28 +16,15 @@ use crate::{EventReader, event::InputEvent, reader::Report};
 /// To fetch [`Report`]s, use [`AsyncReports::next_report`].
 #[derive(Debug)]
 pub struct AsyncReports<'a> {
-    was_nonblocking: bool,
-    imp: Impl<'a>,
-}
-
-impl<'a> Drop for AsyncReports<'a> {
-    fn drop(&mut self) {
-        if !self.was_nonblocking {
-            if let Err(e) = self.imp.reader().evdev().set_nonblocking(false) {
-                log::error!(
-                    "failed to move `Evdev` back into blocking mode in `ReportStream` destructor: {e}"
-                );
-            }
-        }
-    }
+    helper: AsyncHelper,
+    reader: &'a mut EventReader,
 }
 
 impl<'a> AsyncReports<'a> {
     pub(crate) fn new(reader: &'a mut EventReader) -> io::Result<Self> {
-        let was_nonblocking = reader.evdev().set_nonblocking(true)?;
         Ok(Self {
-            was_nonblocking,
-            imp: Impl::new(reader)?,
+            helper: AsyncHelper::new(reader.as_raw_fd())?,
+            reader,
         })
     }
 
@@ -45,7 +32,12 @@ impl<'a> AsyncReports<'a> {
     ///
     /// When using the `"tokio"` feature, this method must be called from within a tokio context.
     pub async fn next_report(&mut self) -> io::Result<Report> {
-        self.imp.next_report().await
+        self.helper
+            .asyncify(|| match self.reader.reports().next() {
+                Some(res) => Poll::Ready(res),
+                None => Poll::Pending,
+            })
+            .await
     }
 }
 
@@ -58,28 +50,15 @@ impl<'a> AsyncReports<'a> {
 /// To fetch [`InputEvent`]s, use [`AsyncEvents::next_event`].
 #[derive(Debug)]
 pub struct AsyncEvents<'a> {
-    was_nonblocking: bool,
-    imp: Impl<'a>,
-}
-
-impl<'a> Drop for AsyncEvents<'a> {
-    fn drop(&mut self) {
-        if !self.was_nonblocking {
-            if let Err(e) = self.imp.reader().evdev().set_nonblocking(false) {
-                log::error!(
-                    "failed to move `Evdev` back into blocking mode in `EventStream` destructor: {e}"
-                );
-            }
-        }
-    }
+    helper: AsyncHelper,
+    reader: &'a mut EventReader,
 }
 
 impl<'a> AsyncEvents<'a> {
     pub(crate) fn new(reader: &'a mut EventReader) -> io::Result<Self> {
-        let was_nonblocking = reader.evdev().set_nonblocking(true)?;
         Ok(Self {
-            was_nonblocking,
-            imp: Impl::new(reader)?,
+            helper: AsyncHelper::new(reader.as_raw_fd())?,
+            reader,
         })
     }
 
@@ -87,83 +66,28 @@ impl<'a> AsyncEvents<'a> {
     ///
     /// When using the `"tokio"` feature, this method must be called from within a tokio context.
     pub async fn next_event(&mut self) -> io::Result<InputEvent> {
-        self.imp.next_event().await
+        self.helper
+            .asyncify(|| match self.reader.events().next() {
+                Some(res) => Poll::Ready(res),
+                None => Poll::Pending,
+            })
+            .await
     }
 }
 
-#[cfg(feature = "tokio")]
-mod tokio_impl {
-    use std::{
-        io,
-        os::fd::{AsRawFd, RawFd},
+#[cfg(test)]
+mod tests {
+    use std::{io, pin::pin};
+
+    use crate::{
+        event::{Rel, RelEvent, Syn},
+        test::{AssertPending, check_events, pair},
+        util::r#async::with_runtime,
     };
 
-    use tokio::io::{Interest, unix::AsyncFd};
-
-    use crate::{EventReader, event::InputEvent, reader::Report};
-
-    #[derive(Debug)]
-    pub struct Impl<'a> {
-        fd: AsyncFd<RawFd>,
-        reader: &'a mut EventReader,
-    }
-
-    impl<'a> Impl<'a> {
-        pub fn new(reader: &'a mut EventReader) -> io::Result<Self> {
-            // Note: only register with READABLE interest; otherwise this fails with EINVAL on FreeBSD.
-            let fd = AsyncFd::with_interest(reader.as_raw_fd(), Interest::READABLE)?;
-            Ok(Self { fd, reader })
-        }
-
-        pub fn reader(&self) -> &EventReader {
-            self.reader
-        }
-
-        pub async fn next_event(&mut self) -> io::Result<InputEvent> {
-            if let Some(res) = self.reader.events().next() {
-                return res;
-            }
-
-            loop {
-                let mut guard = self.fd.readable().await?;
-                match self.reader.events().next() {
-                    Some(res) => return res,
-                    None => guard.clear_ready(), // `WouldBlock`
-                }
-            }
-        }
-
-        pub async fn next_report(&mut self) -> io::Result<Report> {
-            if let Some(res) = self.reader.reports().next() {
-                return res;
-            }
-
-            loop {
-                let mut guard = self.fd.readable().await?;
-                match self.reader.reports().next() {
-                    Some(res) => return res,
-                    None => guard.clear_ready(), // `WouldBlock`
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use std::{io, pin::pin};
-
-        use crate::{
-            event::{Rel, RelEvent, Syn},
-            test::{AssertPending, check_events, pair},
-        };
-
-        #[test]
-        fn smoke() -> io::Result<()> {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_io()
-                .build()?;
-            let _guard = rt.enter();
-
+    #[test]
+    fn smoke() -> io::Result<()> {
+        with_runtime(|rt| {
             let (uinput, evdev) = pair(|b| b.with_rel_axes([Rel::DIAL]))?;
             let mut reader = evdev.into_reader()?;
             let mut events = reader.async_events()?;
@@ -196,114 +120,6 @@ mod tokio_impl {
             );
 
             Ok(())
-        }
+        })
     }
 }
-
-#[cfg(feature = "tokio")]
-use tokio_impl::*;
-
-#[cfg(feature = "async-io")]
-mod asyncio_impl {
-    use std::io;
-
-    use async_io::Async;
-
-    use crate::{EventReader, event::InputEvent, reader::Report};
-
-    #[derive(Debug)]
-    pub struct Impl<'a> {
-        reader: Async<&'a mut EventReader>,
-    }
-
-    impl<'a> Impl<'a> {
-        pub fn new(reader: &'a mut EventReader) -> io::Result<Self> {
-            let reader = Async::new(reader)?;
-            Ok(Self { reader })
-        }
-
-        pub fn reader(&self) -> &EventReader {
-            self.reader.get_ref()
-        }
-
-        pub async fn next_event(&mut self) -> io::Result<InputEvent> {
-            if let Some(res) = unsafe { self.reader.get_mut().events().next() } {
-                return res;
-            }
-
-            loop {
-                self.reader.readable().await?;
-                if let Some(res) = unsafe { self.reader.get_mut().events().next() } {
-                    return res;
-                }
-            }
-        }
-
-        pub async fn next_report(&mut self) -> io::Result<Report> {
-            if let Some(res) = unsafe { self.reader.get_mut().reports().next() } {
-                return res;
-            }
-
-            loop {
-                self.reader.readable().await?;
-                if let Some(res) = unsafe { self.reader.get_mut().reports().next() } {
-                    return res;
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use std::{io, pin::pin};
-
-        use async_io::block_on;
-
-        use crate::{
-            event::{Rel, RelEvent, Syn},
-            test::{AssertPending, check_events, pair},
-        };
-
-        #[test]
-        fn smoke() -> io::Result<()> {
-            let (uinput, evdev) = pair(|b| b.with_rel_axes([Rel::DIAL]))?;
-            let mut reader = evdev.into_reader()?;
-            let mut events = reader.async_events()?;
-
-            {
-                let mut fut = pin!(events.next_event());
-                block_on(AssertPending(fut.as_mut()));
-
-                uinput.write(&[RelEvent::new(Rel::DIAL, 1).into()])?;
-
-                let event = block_on(fut)?;
-                check_events([event], [RelEvent::new(Rel::DIAL, 1).into()]);
-            }
-
-            drop(events);
-            let ev = reader.events().next().unwrap()?;
-            check_events([ev], [Syn::REPORT.into()]);
-
-            let mut reports = reader.async_reports()?;
-            let mut fut = pin!(reports.next_report());
-            block_on(AssertPending(fut.as_mut()));
-
-            uinput.write(&[RelEvent::new(Rel::DIAL, 2).into()])?;
-
-            let report = block_on(fut)?;
-            assert_eq!(report.len(), 2);
-            check_events(
-                report,
-                [RelEvent::new(Rel::DIAL, 2).into(), Syn::REPORT.into()],
-            );
-
-            Ok(())
-        }
-    }
-}
-
-#[cfg(feature = "async-io")]
-use asyncio_impl::*;
-
-#[cfg(doc)]
-struct Impl<'a>(&'a ());

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,8 @@ use std::{
     os::fd::{AsRawFd, RawFd},
 };
 
+pub mod r#async;
+
 /// Uses `poll(2)` to determine whether reading from `fd` is possible without blocking.
 pub fn is_readable(fd: RawFd) -> io::Result<bool> {
     let mut poll = libc::pollfd {

--- a/src/util/async.rs
+++ b/src/util/async.rs
@@ -1,0 +1,182 @@
+#![cfg(any(doc, feature = "tokio", feature = "async-io"))]
+
+use std::{io, os::fd::RawFd, task::Poll};
+
+use crate::util::set_nonblocking;
+
+/// A helper that makes an operation `async`.
+///
+/// The target file descriptor is moved into non-blocking mode when the `AsyncHelper` is created,
+/// and back out when it is dropped (unless the caller has already put it in non-blocking mode).
+///
+/// The `asyncify` method can then be used to integrate into an async runtime.
+#[derive(Debug)]
+pub struct AsyncHelper {
+    fd: RawFd,
+    was_nonblocking: bool,
+    imp: Impl,
+}
+
+impl AsyncHelper {
+    pub fn new(fd: RawFd) -> io::Result<Self> {
+        let was_nonblocking = set_nonblocking(fd, true)?;
+        Ok(Self {
+            fd,
+            was_nonblocking,
+            imp: Impl::new(fd)?,
+        })
+    }
+
+    /// Turns an operation `async`.
+    ///
+    /// `op` must return `Poll::Pending` when the underlying read fails with `WouldBlock`, and
+    /// `Poll::Ready` when a result is available.
+    /// `AsyncHelper` will handle the rest of the job (such as registering the fd with the selected
+    /// async backend, and waiting until the fd is readable again).
+    pub async fn asyncify<T>(&self, op: impl FnMut() -> Poll<io::Result<T>>) -> io::Result<T> {
+        self.imp.asyncify(op).await
+    }
+}
+
+impl Drop for AsyncHelper {
+    fn drop(&mut self) {
+        if self.was_nonblocking {
+            return;
+        }
+
+        if let Err(e) = set_nonblocking(self.fd, false) {
+            log::error!("failed to move fd back into blocking mode: {e}");
+        }
+    }
+}
+
+#[cfg(feature = "tokio")]
+use tokio_impl::*;
+#[cfg(feature = "tokio")]
+mod tokio_impl {
+    use std::{io, os::fd::RawFd, task::Poll};
+
+    use tokio::io::{Interest, unix::AsyncFd};
+
+    #[derive(Debug)]
+    pub struct Impl(AsyncFd<RawFd>);
+
+    impl Impl {
+        pub fn new(fd: RawFd) -> io::Result<Self> {
+            // Note: only register with READABLE interest; otherwise this fails with EINVAL on FreeBSD.
+            let fd = AsyncFd::with_interest(fd, Interest::READABLE)?;
+            Ok(Self(fd))
+        }
+
+        pub async fn asyncify<T>(
+            &self,
+            mut op: impl FnMut() -> Poll<io::Result<T>>,
+        ) -> io::Result<T> {
+            let mut guard = None;
+            loop {
+                match op() {
+                    Poll::Pending => guard = Some(self.0.readable().await?),
+                    Poll::Ready(res) => {
+                        if let Some(mut guard) = guard {
+                            guard.clear_ready();
+                        }
+                        return res;
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub struct Runtime {
+        rt: tokio::runtime::Runtime,
+    }
+
+    #[cfg(test)]
+    impl Runtime {
+        pub fn new() -> io::Result<Self> {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .build()?;
+            Ok(Self { rt })
+        }
+
+        pub fn enter(&self) -> impl Sized + '_ {
+            self.rt.enter()
+        }
+
+        pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
+            self.rt.block_on(fut)
+        }
+    }
+}
+
+#[cfg(feature = "async-io")]
+use asyncio_impl::*;
+#[cfg(feature = "async-io")]
+mod asyncio_impl {
+    use std::{
+        io,
+        os::fd::{BorrowedFd, RawFd},
+        task::Poll,
+    };
+
+    use async_io::Async;
+
+    #[derive(Debug)]
+    pub struct Impl(Async<BorrowedFd<'static>>);
+
+    impl Impl {
+        pub fn new(fd: RawFd) -> io::Result<Self> {
+            let fd = unsafe { BorrowedFd::borrow_raw(fd) };
+            Async::new(fd).map(Self)
+        }
+
+        pub async fn asyncify<T>(
+            &self,
+            mut op: impl FnMut() -> Poll<io::Result<T>>,
+        ) -> io::Result<T> {
+            loop {
+                match op() {
+                    Poll::Pending => self.0.readable().await?,
+                    Poll::Ready(res) => return res,
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub struct Runtime;
+
+    #[cfg(test)]
+    impl Runtime {
+        pub fn new() -> io::Result<Self> {
+            Ok(Self)
+        }
+
+        pub fn enter(&self) -> impl Sized + '_ {}
+
+        pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
+            async_io::block_on(fut)
+        }
+    }
+}
+
+// These definitions override the glob-imported ones above and make the documentation build with
+// `--all-features`.
+#[cfg(doc)]
+pub struct Impl;
+#[cfg(doc)]
+pub struct Runtime;
+
+/// Calls `f` with an instance of the selected async runtime.
+///
+/// Allows writing async-runtime-agnostic tests.
+///
+/// The only supported API is `runtime.block_on(future)`.
+#[cfg(test)]
+pub fn with_runtime<R>(f: impl FnOnce(&Runtime) -> io::Result<R>) -> io::Result<R> {
+    let rt = Runtime::new()?;
+    let _guard = rt.enter();
+    f(&rt)
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,9 +1,13 @@
+//! Runs unit tests with different feature flags.
+//!
+//! Some tests will adapt to the selected async runtime automatically. This test exercises them.
+
 use std::{env, process::Command};
 
 fn test(args: &[&str]) {
     let cargo = env::var_os("CARGO").expect("`CARGO` isn't set");
     let status = Command::new(cargo)
-        .args(&["test", "-p", "evdevil", "--lib"])
+        .args(&["test", "-p", "evdevil", "--lib"]) // avoid infinite recursion
         .args(args)
         .status()
         .unwrap();


### PR DESCRIPTION
Also refactors the `async` stuff to be more reusable across parts of the library.